### PR TITLE
Added Kubernetes Service and replicationController Support

### DIFF
--- a/k8s/reveal-controller.json
+++ b/k8s/reveal-controller.json
@@ -1,0 +1,53 @@
+{
+  "id": "gist-reveal-controller",
+  "kind": "ReplicationController",
+  "apiVersion": "v1beta1",
+  "desiredState": {
+    "replicas": 2,
+    "replicaSelector": {"name": "gist-reveal"},
+    "podTemplate": {
+      "desiredState": {
+         "manifest": {
+           "version": "v1beta1",
+           "id": "gsit-reveal-controller",
+           "containers": [{
+             "name": "gist-reveal",
+             "image": "ryanj/gist-reveal.it",
+             "env": [
+               {
+                 "name": "OPENSHIFT_APP_DNS",
+                 "value": "${OPENSHIFT_APP_DNS}"
+               },
+               {
+                 "name": "IP_ADDR",
+                 "value": "${IP_ADDR}"
+               },
+               {
+                 "name": "GA_TRACKER",
+                 "value": "${GA_TRACKER}"
+               },
+               {
+                 "name": "REVEAL_SOCKET_SECRET",
+                 "value": "${REVEAL_SOCKET_SECRET}"
+               },
+               {
+                 "name": "DEFAULT_GIST",
+                 "value": "${DEFAULT_GIST}"
+               },
+               {
+                 "name": "GH_CLIENT_ID",
+                 "value": "${GH_CLIENT_ID}"
+               },
+               {
+                 "name": "GH_CLIENT_SECRET",
+                 "value": "${GH_CLIENT_SECRET}"
+               }
+             ],
+             "ports": [{"containerPort": 8080}]
+           }]
+         }
+       },
+       "labels": {"name": "gist-reveal"}
+      }},
+  "labels": {"name": "gist-reveal"}
+}

--- a/k8s/reveal-pod.json
+++ b/k8s/reveal-pod.json
@@ -1,0 +1,52 @@
+{
+  "id": "gist-reveal",
+  "kind": "Pod",
+  "apiVersion": "v1beta1",
+  "desiredState": {
+    "manifest": {
+      "version": "v1beta1",
+      "id": "gist-reveal",
+      "containers": [{
+        "name": "gist-reveal",
+        "image": "ryanj/gist-reveal.it",
+        "env": [
+          {
+            "name": "OPENSHIFT_APP_DNS",
+            "value": "${OPENSHIFT_APP_DNS}"
+          },
+          {
+            "name": "IP_ADDR",
+            "value": "${IP_ADDR}"
+          },
+          {
+            "name": "GA_TRACKER",
+            "value": "${GA_TRACKER}"
+          },
+          {
+            "name": "REVEAL_SOCKET_SECRET",
+            "value": "${REVEAL_SOCKET_SECRET}"
+          },
+          {
+            "name": "DEFAULT_GIST",
+            "value": "${DEFAULT_GIST}"
+          },
+          {
+            "name": "GH_CLIENT_ID",
+            "value": "${GH_CLIENT_ID}"
+          },
+          {
+            "name": "GH_CLIENT_SECRET",
+            "value": "${GH_CLIENT_SECRET}"
+          }
+        ],
+        "ports": [{
+          "hostPort": 80,
+          "containerPort": 8080,
+        }]
+      }]
+    }
+  },
+  "labels": {
+    "name": "gist-reveal"
+  }
+}

--- a/k8s/reveal-service.yaml
+++ b/k8s/reveal-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1beta1
+containerPort: 8080
+id: gist-reveal
+kind: Service
+port: 80
+selector:
+  name: gist-reveal


### PR DESCRIPTION
Previously, the project only supported a pod definition. This
patch adds a replicationController and service defintion files.

The patch also groups the kube files into a k8s DIR.
